### PR TITLE
removed clear filter button

### DIFF
--- a/components/FilterCuisine.tsx
+++ b/components/FilterCuisine.tsx
@@ -48,16 +48,6 @@ const FilterCuisine: React.FC<FilterCuisineProps> = ({
           </TouchableOpacity>
         ))}
       </ScrollView>
-      {selectedCuisine && (
-        <TouchableOpacity
-          style={styles.clearButton}
-          onPress={() => {
-            setSelectedCuisine(null);
-            onCuisineSelect(null);
-          }}>
-          <Text style={styles.clearButtonText}>Clear Filter</Text>
-        </TouchableOpacity>
-      )}
     </View>
   );
 };


### PR DESCRIPTION
removed clear filter button when a cuisine is selected so that the ui is not moved every time on cuisine selection,
the user can remove the selected cuisine simply by clicking on it again.